### PR TITLE
Bug fix + support for callbacks

### DIFF
--- a/src/algorithms/distributed_gibbs.jl
+++ b/src/algorithms/distributed_gibbs.jl
@@ -20,21 +20,7 @@ function gibbs_sample!(
     max_time = model.max_time
 
     # Partition spikes.
-    split_points = Tuple(p * max_time / num_partitions for p in 0:num_partitions)
-    spk_partition = Tuple(Spike[] for m in model.submodels)
-    assgn_partition = [Int64[] for m in model.submodels]  # TODO -- Tuple?
-    partition_ids = [Int64[] for m in model.submodels]    # TODO -- Tuple?
-
-    for s = 1:length(spikes)
-        for p = 1:model.num_partitions
-            if split_points[p] <= spikes[s].timestamp <= split_points[p + 1]
-                push!(spk_partition[p], spikes[s])
-                push!(assgn_partition[p], initial_assignments[s])
-                push!(partition_ids[p], s)
-                break
-            end
-        end
-    end
+    spk_partition, assgn_partition, partition_ids = partition_spikes(model, spikes, initial_assignments)
 
     # Dense rank assignments within each partition.
     for p = 1:model.num_partitions
@@ -44,11 +30,7 @@ function gibbs_sample!(
 
     # Pass assignments to submodels
     for p in 1:model.num_partitions
-        recompute!(
-            model.submodels[p],
-            spk_partition[p],
-            assgn_partition[p],
-        )
+        recompute!(model.submodels[p], spk_partition[p], assgn_partition[p])
     end
 
     # Save spike assignments over samples.
@@ -145,6 +127,35 @@ function gibbs_sample!(
         latent_event_hist,
         globals_hist
     )
+end
+
+"""
+    partition_spikes(model::DistributedSeqModel, spikes, assignments)
+
+Partition spikes among the various submodels.
+"""
+function partition_spikes(model::DistributedSeqModel, spikes, assignments)
+    max_time = model.max_time
+    num_partitions = model.num_partitions
+
+    # Partition spikes.
+    split_points = Tuple(p * max_time / num_partitions for p in 0:num_partitions)
+    spk_partition = Tuple(Spike[] for m in model.submodels)
+    assgn_partition = [Int64[] for m in model.submodels]  # TODO -- Tuple?
+    partition_ids = [Int64[] for m in model.submodels]    # TODO -- Tuple?
+
+    for s = 1:length(spikes)
+        for p = 1:model.num_partitions
+            if split_points[p] <= spikes[s].timestamp <= split_points[p + 1]
+                push!(spk_partition[p], spikes[s])
+                push!(assgn_partition[p], assignments[s])
+                push!(partition_ids[p], s)
+                break
+            end
+        end
+    end
+
+    return spk_partition, assgn_partition, partition_ids
 end
 
 

--- a/src/algorithms/distributed_gibbs.jl
+++ b/src/algorithms/distributed_gibbs.jl
@@ -17,7 +17,7 @@ function gibbs_sample!(
     end
 
     num_partitions = model.num_partitions
-    max_time = model.primary_model.max_time
+    max_time = model.max_time
 
     # Partition spikes.
     split_points = Tuple(p * max_time / num_partitions for p in 0:num_partitions)
@@ -133,6 +133,7 @@ function gibbs_sample!(
             push!(globals_hist, deepcopy(model.primary_model.globals))
 
             verbose && print(s, "-")
+            flush(stdout)
         end
     end
     verbose && println("Done")

--- a/src/algorithms/easy_sample_masked.jl
+++ b/src/algorithms/easy_sample_masked.jl
@@ -9,7 +9,8 @@ function easy_sample_masked!(
         spikes::Vector{Spike},
         masks::Vector{Mask},
         initial_assignments::Vector{Int64},
-        config::Dict
+        config::Dict;
+        callback=(args...) -> nothing,
     )
 
     # Save copy of initial assignments.
@@ -36,7 +37,8 @@ function easy_sample_masked!(
         config[:split_merge_moves_during_anneal],
         config[:split_merge_window],
         config[:save_every_during_anneal];
-        verbose=true
+        verbose=true,
+        callback=callback,
     )
 
     # Draw regular masked Gibbs samples.
@@ -58,7 +60,8 @@ function easy_sample_masked!(
         config[:split_merge_moves_after_anneal],
         config[:split_merge_window],
         config[:save_every_after_anneal];
-        verbose=true
+        verbose=true,
+        callback=callback,
     )
 
     # return the results

--- a/src/algorithms/gibbs.jl
+++ b/src/algorithms/gibbs.jl
@@ -91,6 +91,7 @@ function gibbs_sample!(
 
             # Display progress.
             verbose && print(s, "-")
+            flush(stdout)
         end
     end
 

--- a/src/algorithms/masked_gibbs.jl
+++ b/src/algorithms/masked_gibbs.jl
@@ -207,10 +207,9 @@ function annealed_masked_gibbs!(
             model,
             log(α) + log(λ) + log(model.max_time) + α * (log(β) - log(1 + β))
         )
-        model.bkgd_log_prob = (
-            log(model.globals.bkgd_amplitude)
-            + log(model.max_time)
-            + log(1 + β)
+        set_bkgd_log_prob!(
+            model,
+            log(model.globals.bkgd_amplitude) + log(model.max_time) + log(1 + β)
         )
 
         # Draw gibbs samples.

--- a/src/algorithms/masked_gibbs.jl
+++ b/src/algorithms/masked_gibbs.jl
@@ -15,7 +15,8 @@ function masked_gibbs!(
         extra_split_merge_moves::Int64,
         split_merge_window::Float64,
         save_every::Int64;
-        verbose::Bool=true
+        verbose::Bool=true,
+        callback=(args...) -> nothing,
     )
 
     sampled_spikes = Spike[]
@@ -56,6 +57,8 @@ function masked_gibbs!(
     unmasked_assignments = initial_assignments
 
     for i = 1:num_spike_resamples
+        callback()
+        flush(stdout)
 
         # Sample new spikes in each masked region.
         sample_masked_spikes!(
@@ -154,7 +157,8 @@ function annealed_masked_gibbs!(
         extra_split_merge_moves::Int64,
         split_merge_window::Float64,
         save_every::Int64;
-        verbose::Bool=true
+        verbose::Bool=true,
+        callback=(args...) -> nothing,
     )
 
     masked_spikes, unmasked_spikes = split_spikes_by_mask(spikes, masks)
@@ -229,7 +233,8 @@ function annealed_masked_gibbs!(
             extra_split_merge_moves,
             split_merge_window,
             save_every;
-            verbose=verbose
+            verbose=verbose,
+            callback=callback,
         )
 
         # Save samples.
@@ -263,7 +268,8 @@ function masked_gibbs!(
         extra_split_merge_moves::Int64,
         split_merge_window::Float64,
         save_every::Int64;
-        verbose::Bool=true
+        verbose::Bool=true,
+        callback=(args...) -> nothing,
     )
 
     masked_spikes, unmasked_spikes = split_spikes_by_mask(spikes, masks)
@@ -279,7 +285,8 @@ function masked_gibbs!(
         extra_split_merge_moves,
         split_merge_window,
         save_every;
-        verbose=verbose
+        verbose=verbose,
+        callback=callback
     )
 end
 
@@ -394,7 +401,7 @@ function compute_complementary_masks(
                 )
                 break
             end
-            @assert (i + 1) != length(inverted_masks)
+            @assert i != length(inverted_masks[n])
         end
     end
 

--- a/src/model/events.jl
+++ b/src/model/events.jl
@@ -122,10 +122,10 @@ end
 Recompute sufficient statistics for all sequence events.
 """
 function recompute!(
-        model::SeqModel,
-        spikes::Vector{Spike},
-        assignments::AbstractVector{Int64}
-    )
+    model::SeqModel,
+    spikes::Vector{Spike},
+    assignments::AbstractVector{Int64}
+)
     
     # Grab sequence event list.
     ev = model.sequence_events
@@ -167,6 +167,18 @@ function recompute!(
     for k in ev.indices
         set_posterior!(model, k)
     end
+end
+
+function recompute!(
+    model::DistributedSeqModel, 
+    spikes, 
+    assignments,
+)
+    # Partition spikes.
+    spk_partition, assgn_partition, partition_ids = partition_spikes(model, spikes, assignments)
+
+    # Pass assignments to submodels
+    recompute!.(model.submodels, spk_partition, assgn_partition)
 end
 
 

--- a/src/model/structs.jl
+++ b/src/model/structs.jl
@@ -340,3 +340,11 @@ mutable struct DistributedSeqModel
     num_partitions::Int64
     submodels::Vector{SeqModel}    
 end
+
+function Base.getproperty(obj::DistributedSeqModel, sym::Symbol)
+    if hasfield(DistributedSeqModel, sym)
+        return getfield(obj, sym)
+    else
+        return getproperty(obj.primary_model, sym)
+    end
+end


### PR DESCRIPTION
This PR makes three changes
- I believe I fixed what was an incorrect assertion on line 397 of `masked_gibbs.jl`. @ahwillia Can you verify?
- Sometimes Julia / IJulia delay `stdout`. Added a line to immediately flush `stdout` at each masked Gibbs iteration.
- Added support for callbacks. One can now do `callback = () -> println(time())` and pass this as a keyword argument to the masked Gibbs sampler, e.g.,
```julia
results = seq.easy_sample_masked!(model, spikes, masks, init_assignments, config, callback=callback);
```